### PR TITLE
- `graphviz` installation as additional prerequisite step for `YAD2K`;

### DIFF
--- a/Convert/coreml.py
+++ b/Convert/coreml.py
@@ -19,4 +19,4 @@ coreml_model.output_description['grid'] = 'The 13x13 grid with the bounding box 
 
 print(coreml_model)
 
-#coreml_model.save('../TinyYOLO-CoreML/TinyYOLO-CoreML/TinyYOLO.mlmodel')
+coreml_model.save('../TinyYOLO-CoreML/TinyYOLO-CoreML/TinyYOLO.mlmodel')

--- a/README.markdown
+++ b/README.markdown
@@ -38,6 +38,7 @@ pip3 install keras==1.2.2
 pip3 install h5py
 pip3 install pydot-ng
 pip3 install pillow
+brew install graphviz
 ```
 
 Run the yad2k.py script to convert the Darknet model to Keras:


### PR DESCRIPTION
Without it, you get:

`ImportError: Failed to import pydot. You must install pydot and graphviz for `pydotprint` to work.`